### PR TITLE
Update JWT Provider 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^8.5|^9.0",
         "squizlabs/php_codesniffer": "~2.0",
-        "tymon/jwt-auth": "1.0.*"
+        "php-open-source-saver/jwt-auth": "^1.4",
     },
     "suggest": {
-        "tymon/jwt-auth": "Protect your API with JSON Web Tokens."
+        "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens."
     },
     "autoload": {
         "psr-4": {

--- a/src/Auth/Provider/JWT.php
+++ b/src/Auth/Provider/JWT.php
@@ -3,10 +3,10 @@
 namespace Dingo\Api\Auth\Provider;
 
 use Exception;
-use Tymon\JWTAuth\JWTAuth;
+use PHPOpenSourceSaver\JWTAuth\JWTAuth;
 use Dingo\Api\Routing\Route;
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class JWT extends Authorization
@@ -14,14 +14,14 @@ class JWT extends Authorization
     /**
      * The JWTAuth instance.
      *
-     * @var \Tymon\JWTAuth\JWTAuth
+     * @var \PHPOpenSourceSaver\JWTAuth\JWTAuth
      */
     protected $auth;
 
     /**
      * Create a new JWT provider instance.
      *
-     * @param \Tymon\JWTAuth\JWTAuth $auth
+     * @param \PHPOpenSourceSaver\JWTAuth\JWTAuth $auth
      *
      * @return void
      */

--- a/tests/Auth/Provider/JWTTest.php
+++ b/tests/Auth/Provider/JWTTest.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 use Mockery as m;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 
 class JWTTest extends BaseTestCase
 {
@@ -20,7 +20,7 @@ class JWTTest extends BaseTestCase
     {
         parent::setUp();
 
-        $this->auth = m::mock('Tymon\JWTAuth\JWTAuth');
+        $this->auth = m::mock('PHPOpenSourceSaver\JWTAuth\JWTAuth');
         $this->provider = new JWT($this->auth);
     }
 


### PR DESCRIPTION
As stated in the previous pull request on the original repository.  

Let's update the default JWT Provider to the new community-driven fork which has taken over general support and updates of the repository. 

I am happy for you to make edits if required.

Thanks,
Matthew