### PR TITLE
fix: error in using console command `php artisan api:routes`

### DIFF
--- a/src/Console/Command/Routes.php
+++ b/src/Console/Command/Routes.php
@@ -98,6 +98,8 @@ class Routes extends RouteListCommand
             foreach ($collection->getRoutes() as $route) {
                 $routes[] = $this->filterRoute([
                     'host' => $route->domain(),
+                    'domain' => $route->domain(),
+                    'middleware' => json_encode($route->middleware()),
                     'method' => implode('|', $route->methods()),
                     'uri' => $route->uri(),
                     'name' => $route->getName(),

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -690,7 +690,7 @@ class Router
             }
         }
 
-        return is_null($version) ? $collections : $collections[$version];
+        return is_null($version) ? collect($collections) : $collections[$version];
     }
 
     /**


### PR DESCRIPTION
Fix errors while using command `php artisan api:routes` to generate api routes list for dingoapi in laravel 9.
