### PR TITLE
Update blueprint version, remove redundant php 8.1 support (^8.0 alre…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,34 +13,28 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^8.0",
         "dingo/blueprint": "^0.4.4",
-        "illuminate/routing": "^7.0|^8.0|^9.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
+        "illuminate/routing": "^9.0",
+        "illuminate/support": "^9.0",
         "league/fractal": "^0.20"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2|~3",
-        "illuminate/auth": "^7.0|^8.0|^9.0",
-        "illuminate/cache": "^7.0|^8.0|^9.0",
-        "illuminate/console": "^7.0|^8.0|^9.0",
-        "illuminate/database": "^7.0|^8.0|^9.0",
-        "illuminate/events": "^7.0|^8.0|^9.0",
-        "illuminate/filesystem": "^7.0|^8.0|^9.0",
-        "illuminate/log": "^7.0|^8.0|^9.0",
-        "illuminate/pagination": "^7.0|^8.0|^9.0",
-        "laravel/lumen-framework": "^7.0|^8.0|^9.0",
+        "friendsofphp/php-cs-fixer": "~3",
+        "illuminate/auth": "^9.0",
+        "illuminate/cache": "^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/events": "^9.0",
+        "illuminate/filesystem": "^9.0",
+        "illuminate/log": "^9.0",
+        "illuminate/pagination": "^9.0",
+        "laravel/lumen-framework": "^9.0",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "^8.5|^9.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "~2.0",
         "php-open-source-saver/jwt-auth": "^1.4"
     },
-    "repositories": [
-      {
-        "type": "vcs",
-        "url": "https://github.com/dmason30/blueprint"
-      }
-    ],
     "suggest": {
         "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens."
     },

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": "^7.2.5|^8.0|^8.1",
-        "dingo/blueprint": "dev-patch-1",
+        "php": "^7.2.5|^8.0",
+        "dingo/blueprint": "^0.4.4",
         "illuminate/routing": "^7.0|^8.0|^9.0",
         "illuminate/support": "^7.0|^8.0|^9.0",
         "league/fractal": "^0.20"

--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -126,7 +126,7 @@ class Factory
         if (! is_null($item)) {
             $class = get_class($item);
         } else {
-            $class = \StdClass::class;
+            $class = \stdClass::class;
         }
 
         if ($parameters instanceof \Closure) {


### PR DESCRIPTION
**Comments:**

- We don't need both PHP ^8.0 and ^8.1  - the former already satisfies the latter
- We need to increase our major version because of the backwards incompatibles changes in tests, so since we will need to do that, there is no need to keep older versions of packages (ie. laravel) in the requirements
- I branched off "V3" from before the "Laravel 9" PR, just in case we need to backport anything into the v3.x.x line.

Tests currently pass, will tag this as v4.0.0