### PR TITLE
change signature of setRouteCollections

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -41,9 +41,9 @@ class UrlGenerator extends IlluminateUrlGenerator
     /**
      * Set the route collection instance.
      *
-     * @param array $collections
+     * @param mixed $collections
      */
-    public function setRouteCollections(array $collections)
+    public function setRouteCollections(mixed $collections)
     {
         $this->collections = $collections;
     }

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Dingo\Api\Tests\Routing;
+
+use Dingo\Api\Routing\Router;
+use Dingo\Api\Routing\UrlGenerator;
+use Dingo\Api\Tests\Stubs\RoutingAdapterStub;
+use Dingo\Api\Tests\Stubs\RoutingControllerStub;
+use Illuminate\Container\Container;
+
+class UrlGeneratorTest extends Adapter\BaseAdapterTest
+{
+    public function getAdapterInstance()
+    {
+        return $this->container->make(RoutingAdapterStub::class);
+    }
+
+    public function getContainerInstance()
+    {
+        return new Container;
+    }
+
+    public function testRouteGenerationSimple()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, null, null);
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo', function() {})->name('my.route');
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route');
+        $this->assertSame('http://localhost/foo', $test);
+    }
+
+    public function testRouteGenerationWithActionAs()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, null, null);
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo', [
+                'as' => 'my.route',
+                'uses' => RoutingControllerStub::class . '@index',
+            ]);
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route');
+        $this->assertSame('http://localhost/foo', $test);
+    }
+
+    public function testRouteGenerationWithDomain()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', null);
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo', function() {})->name('my.route');
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route');
+        $this->assertSame('http://dingo.dev/foo', $test);
+    }
+
+    public function testRouteGenerationWithPrefix()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo', function() {})->name('my.route');
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route');
+        $this->assertSame('http://dingo.dev/api/foo', $test);
+    }
+
+    public function testRouteGenerationWithNamedParameters()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo/{bar}', function() {})->name('my.route');
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route', ['bar' => 'xyz']);
+        $this->assertSame('http://dingo.dev/api/foo/xyz', $test);
+    }
+
+    public function testRouteGenerationWithIndexedParameters()
+    {
+        $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
+        $this->router->version('v1', function (Router $router) {
+            $router->any('foo/{bar}', function() {})->name('my.route');
+        });
+
+        $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
+        $generator->setRouteCollections($this->router->getRoutes());
+
+        $test = $generator->version('v1')->route('my.route', ['xyz']);
+        $this->assertSame('http://dingo.dev/api/foo/xyz', $test);
+    }
+}

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -24,7 +24,8 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
     {
         $this->router = new Router($this->adapter, $this->exception, $this->container, null, null);
         $this->router->version('v1', function (Router $router) {
-            $router->any('foo', function() {})->name('my.route');
+            $router->any('foo', function () {
+            })->name('my.route');
         });
 
         $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
@@ -55,7 +56,8 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
     {
         $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', null);
         $this->router->version('v1', function (Router $router) {
-            $router->any('foo', function() {})->name('my.route');
+            $router->any('foo', function () {
+            })->name('my.route');
         });
 
         $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
@@ -69,7 +71,8 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
     {
         $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
         $this->router->version('v1', function (Router $router) {
-            $router->any('foo', function() {})->name('my.route');
+            $router->any('foo', function () {
+            })->name('my.route');
         });
 
         $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
@@ -83,7 +86,8 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
     {
         $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
         $this->router->version('v1', function (Router $router) {
-            $router->any('foo/{bar}', function() {})->name('my.route');
+            $router->any('foo/{bar}', function () {
+            })->name('my.route');
         });
 
         $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));
@@ -97,7 +101,8 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
     {
         $this->router = new Router($this->adapter, $this->exception, $this->container, 'dingo.dev', 'api');
         $this->router->version('v1', function (Router $router) {
-            $router->any('foo/{bar}', function() {})->name('my.route');
+            $router->any('foo/{bar}', function () {
+            })->name('my.route');
         });
 
         $generator = new UrlGenerator($this->createRequest('/foo', 'GET'));

--- a/tests/Routing/UrlGeneratorTest.php
+++ b/tests/Routing/UrlGeneratorTest.php
@@ -41,7 +41,7 @@ class UrlGeneratorTest extends Adapter\BaseAdapterTest
         $this->router->version('v1', function (Router $router) {
             $router->any('foo', [
                 'as' => 'my.route',
-                'uses' => RoutingControllerStub::class . '@index',
+                'uses' => RoutingControllerStub::class.'@index',
             ]);
         });
 


### PR DESCRIPTION
Hello dingo-api team !

I have a suggest to apply : change signature setRouteCollection (cf commit) because getRoutes into https://github.com/api-ecosystem-for-laravel/dingo-api/blob/master/src/Routing/Router.php#L693 can be a collection, I don't know how to reproduce the bug in the tests to show you (i need more time for that).

Sorry if my PR is not perfect, this bug appeared when I upgraded to Laravel 9 and php8 and changes dingo-api package with your.

Thanks for your answers