### PR TITLE
explode can't be null in php 8 set default include input to empty string

### DIFF
--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -161,7 +161,7 @@ class Fractal implements Adapter
      */
     public function parseFractalIncludes(Request $request)
     {
-        $includes = $request->input($this->includeKey);
+        $includes = $request->input($this->includeKey, '');
 
         if (! is_array($includes)) {
             $includes = array_map('trim', array_filter(explode($this->includeSeparator, $includes)));

--- a/tests/Transformer/Adapter/FractalTest.php
+++ b/tests/Transformer/Adapter/FractalTest.php
@@ -33,4 +33,13 @@ class FractalTest extends BaseTestCase
 
         $this->assertEquals(['foo', 'bar'], $requestedIncludes);
     }
+
+    public function testParseFractalWithoutAnyGivenIncludes()
+    {
+        $request = Request::create('/', 'GET');
+        $this->fractal->parseFractalIncludes($request);
+        $requestedIncludes = $this->fractal->getFractal()->getRequestedIncludes();
+
+        $this->assertEquals([], $requestedIncludes);
+    }
 }


### PR DESCRIPTION
Hello,

I have a suggest to apply because explode can't be null if include input not exist (it gives a php warning)

Sorry if my PR is not perfect, this bug appeared when I upgraded to Laravel 9 and php8 and changes dingo-api package with your.

