### PR TITLE
Fix preg_match function with null value

### DIFF
--- a/src/Http/Parser/Accept.php
+++ b/src/Http/Parser/Accept.php
@@ -67,7 +67,7 @@ class Accept implements Parser
     {
         $pattern = '/application\/'.$this->standardsTree.'\.('.$this->subtype.')\.([\w\d\.\-]+)\+([\w]+)/';
 
-        if (! preg_match($pattern, $request->header('accept'), $matches)) {
+        if (! preg_match($pattern, $request->header('accept') ?? '', $matches)) {
             if ($strict) {
                 throw new BadRequestHttpException('Accept header could not be properly parsed because of a strict matching process.');
             }


### PR DESCRIPTION
It fix this warning:

`preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /www/vendor/api-ecosystem-for-laravel/dingo-api/src/Http/Parser/Accept.php on line 70
`