### PR TITLE
Move affecting type hints from symfony - Laravel 11 support 

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -125,12 +125,12 @@ class Response extends IlluminateResponse
      */
     public function morph($format = 'json')
     {
-        $this->content = $this->getOriginalContent() ?? '';
+        $content = $this->getOriginalContent() ?? '';
 
         $this->fireMorphingEvent();
 
-        if (isset(static::$transformer) && static::$transformer->transformableResponse($this->content)) {
-            $this->content = static::$transformer->transform($this->content);
+        if (isset(static::$transformer) && static::$transformer->transformableResponse($content)) {
+            $content = static::$transformer->transform($content);
         }
 
         $formatter = static::getFormatter($format);
@@ -147,19 +147,21 @@ class Response extends IlluminateResponse
 
         $this->fireMorphedEvent();
 
-        if ($this->content instanceof EloquentModel) {
-            $this->content = $formatter->formatEloquentModel($this->content);
-        } elseif ($this->content instanceof EloquentCollection) {
-            $this->content = $formatter->formatEloquentCollection($this->content);
-        } elseif (is_array($this->content) || $this->content instanceof ArrayObject || $this->content instanceof Arrayable) {
-            $this->content = $formatter->formatArray($this->content);
-        } elseif ($this->content instanceof stdClass) {
-            $this->content = $formatter->formatArray((array) $this->content);
+        if ($content instanceof EloquentModel) {
+            $content = $formatter->formatEloquentModel($content);
+        } elseif ($content instanceof EloquentCollection) {
+            $content = $formatter->formatEloquentCollection($content);
+        } elseif (is_array($content) || $content instanceof ArrayObject || $content instanceof Arrayable) {
+            $content = $formatter->formatArray($content);
+        } elseif ($content instanceof stdClass) {
+            $content = $formatter->formatArray((array) $content);
         } else {
             if (! empty($defaultContentType)) {
                 $this->headers->set('Content-Type', $defaultContentType);
             }
         }
+
+        $this->content = $content;
 
         return $this;
     }


### PR DESCRIPTION
Fix for issue #42 

Moving the type hint at the end of the function.

Borrowed the code from [terax6669](https://github.com/terax6669) just to move forward.