### PR TITLE
replace usage of $this->content for $content to prevent type mismatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": "^8.0|^8.1|^8.2",
+        "php": "^8.0",
         "dingo/blueprint": "~0.4",
         "illuminate/routing": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
@@ -33,7 +33,7 @@
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^9.0|^10.0",
         "squizlabs/php_codesniffer": "~2.0",
-        "php-open-source-saver/jwt-auth": "^2.2"
+        "php-open-source-saver/jwt-auth": "^1.4 | ^2.2"
     },
     "suggest": {
         "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens."

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "jason.lewis1991@gmail.com"
     }],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1|^8.2",
         "dingo/blueprint": "~0.4",
         "illuminate/routing": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
@@ -33,7 +33,7 @@
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^9.0|^10.0",
         "squizlabs/php_codesniffer": "~2.0",
-        "php-open-source-saver/jwt-auth": "^1.4"
+        "php-open-source-saver/jwt-auth": "^2.2"
     },
     "suggest": {
         "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens."

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -39,7 +39,7 @@ class Request extends IlluminateRequest implements RequestInterface
 
         try {
             $session = $old->getSession();
-            if($session instanceof SymfonySessionDecorator){
+            if ($session instanceof SymfonySessionDecorator) {
                 $new->setLaravelSession($session->store);
             }
         } catch (SessionNotFoundException $exception) {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -5,6 +5,7 @@ namespace Dingo\Api\Http;
 use Dingo\Api\Http\Parser\Accept;
 use Illuminate\Http\Request as IlluminateRequest;
 use Dingo\Api\Contract\Http\Request as RequestInterface;
+use Illuminate\Session\SymfonySessionDecorator;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 
 class Request extends IlluminateRequest implements RequestInterface
@@ -37,8 +38,9 @@ class Request extends IlluminateRequest implements RequestInterface
         );
 
         try {
-            if ($session = $old->getSession()) {
-                $new->setLaravelSession($old->getSession());
+            $session = $old->getSession();
+            if($session instanceof SymfonySessionDecorator){
+                $new->setLaravelSession($session->store);
             }
         } catch (SessionNotFoundException $exception) {
         }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -125,12 +125,12 @@ class Response extends IlluminateResponse
      */
     public function morph($format = 'json')
     {
-        $this->content = $this->getOriginalContent() ?? '';
+        $content = $this->getOriginalContent() ?? '';
 
         $this->fireMorphingEvent();
 
-        if (isset(static::$transformer) && static::$transformer->transformableResponse($this->content)) {
-            $this->content = static::$transformer->transform($this->content);
+        if (isset(static::$transformer) && static::$transformer->transformableResponse($content)) {
+            $content = static::$transformer->transform($content);
         }
 
         $formatter = static::getFormatter($format);
@@ -147,19 +147,21 @@ class Response extends IlluminateResponse
 
         $this->fireMorphedEvent();
 
-        if ($this->content instanceof EloquentModel) {
-            $this->content = $formatter->formatEloquentModel($this->content);
-        } elseif ($this->content instanceof EloquentCollection) {
-            $this->content = $formatter->formatEloquentCollection($this->content);
-        } elseif (is_array($this->content) || $this->content instanceof ArrayObject || $this->content instanceof Arrayable) {
-            $this->content = $formatter->formatArray($this->content);
-        } elseif ($this->content instanceof stdClass) {
-            $this->content = $formatter->formatArray((array) $this->content);
+        if ($content instanceof EloquentModel) {
+            $content = $formatter->formatEloquentModel($content);
+        } elseif ($content instanceof EloquentCollection) {
+            $content = $formatter->formatEloquentCollection($content);
+        } elseif (is_array($content) || $content instanceof ArrayObject || $content instanceof Arrayable) {
+            $content = $formatter->formatArray($content);
+        } elseif ($content instanceof stdClass) {
+            $content = $formatter->formatArray((array) $content);
         } else {
             if (! empty($defaultContentType)) {
                 $this->headers->set('Content-Type', $defaultContentType);
             }
         }
+
+        $this->content = $content;
 
         return $this;
     }


### PR DESCRIPTION
While using a newer version of Symfony, the attribute $content defines its type to string and this causes a type issue when returning `$this->getOriginalContent()` as this method returns `mixed`