### PR TITLE
Make blueprint an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     }],
     "require": {
         "php": "^8.0",
-        "dingo/blueprint": "~0.4",
         "illuminate/routing": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
         "league/fractal": "^0.20"
@@ -33,10 +32,13 @@
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^9.0|^10.0",
         "squizlabs/php_codesniffer": "~2.0",
-        "php-open-source-saver/jwt-auth": "^1.4 | ^2.2"
+        "php-open-source-saver/jwt-auth": "^1.4 | ^2.2",
+        "dingo/blueprint": "~0.4"
     },
     "suggest": {
-        "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens."
+        "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens.",
+        "specialtactics/laravel-api-boilerplate": "API Boilerplate for Laravel",
+        "dingo/blueprint": "Legacy package which can produce API docs from dingo/api"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Please note, we do not actively maintain the Lumen support of this project. If y
 
 The Dingo API package is meant to provide you, the developer, with a set of tools to help you easily and quickly build your own API. While the goal of this package is to remain as flexible as possible it still won't cover all situations and solve all problems.
 
-[!Build Status](https://github.com/api-ecosystem-for-laravel/dingo-api/actions/workflows/ci.yml/badge.svg?branch=master)
+[![CI Tests](https://github.com/api-ecosystem-for-laravel/dingo-api/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/api-ecosystem-for-laravel/dingo-api/actions)
 [![License](https://img.shields.io/packagist/l/api-ecosystem-for-laravel/dingo-api.svg?style=flat-square)](LICENSE)
 [![Development Version](https://img.shields.io/packagist/vpre/api-ecosystem-for-laravel/dingo-api.svg?style=flat-square)](https://packagist.org/packages/api-ecosystem-for-laravel/dingo-api)
 [![Monthly Installs](https://img.shields.io/packagist/dm/api-ecosystem-for-laravel/dingo-api.svg?style=flat-square)](https://packagist.org/packages/api-ecosystem-for-laravel/dingo-api)

--- a/src/Provider/DingoServiceProvider.php
+++ b/src/Provider/DingoServiceProvider.php
@@ -186,16 +186,18 @@ class DingoServiceProvider extends ServiceProvider
      */
     protected function registerDocsCommand()
     {
-        $this->app->singleton(\Dingo\Api\Console\Command\Docs::class, function ($app) {
-            return new Command\Docs(
-                $app[\Dingo\Api\Routing\Router::class],
-                $app[\Dingo\Blueprint\Blueprint::class],
-                $app[\Dingo\Blueprint\Writer::class],
-                $this->config('name'),
-                $this->config('version')
-            );
-        });
+        if (class_exists(\Dingo\Blueprint\Blueprint::class)) {
+            $this->app->singleton(\Dingo\Api\Console\Command\Docs::class, function ($app) {
+                return new Command\Docs(
+                    $app[\Dingo\Api\Routing\Router::class],
+                    $app[\Dingo\Blueprint\Blueprint::class],
+                    $app[\Dingo\Blueprint\Writer::class],
+                    $this->config('name'),
+                    $this->config('version')
+                );
+            });
 
-        $this->commands([\Dingo\Api\Console\Command\Docs::class]);
+            $this->commands([\Dingo\Api\Console\Command\Docs::class]);
+        }
     }
 }


### PR DESCRIPTION
Makes blueprint an optional dependency. It can still be used and will work the same, but needs to be manually included in the project's composer.json
This is designed to decouple this package from the blueprint package, which is less maintained and has been a blocker in the past to get updates out.

Fix up CI image