### PR TITLE
Add ability to pass params to url generator route()

### DIFF
--- a/src/Facade/API.php
+++ b/src/Facade/API.php
@@ -94,11 +94,12 @@ class API extends Facade
      * Get the API route of the given name, and optionally specify the API version.
      *
      * @param string $routeName
+     * @param array $parameters
      * @param string $apiVersion
      * @return string
      */
-    public static function route($routeName, $apiVersion = 'v1')
+    public static function route($routeName, $parameters = [], $apiVersion = 'v1')
     {
-        return static::$app['api.url']->version($apiVersion)->route($routeName);
+        return static::$app['api.url']->version($apiVersion)->route($routeName, $parameters);
     }
 }


### PR DESCRIPTION
At the moment, it's not possible to pass any params to the dingo url generator, but there should be.

This has a small change of breaking if someone is using it with specifying an API version.