### PR TITLE
Adds support for distinct simple paginator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php-open-source-saver/fractal": "^1.0"
     },
     "require-dev": {
+        "dingo/blueprint": "~0.4",
         "friendsofphp/php-cs-fixer": "~3",
         "illuminate/auth": "^9.0|^10.0|^11.0",
         "illuminate/cache": "^9.0|^10.0|^11.0",
@@ -28,12 +29,12 @@
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/log": "^9.0|^10.0|^11.0",
         "illuminate/pagination": "^9.0|^10.0|^11.0",
-        "laravel/lumen-framework": "^9.0|^10.0|^11.0",
+        "laravel/framework": "^9.0|^10.0|^11.0",
+        "illuminate/translation": "^9.0|^10.0|^11.0",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "^9.0|^10.0",
-        "squizlabs/php_codesniffer": "~2.0",
         "php-open-source-saver/jwt-auth": "^1.4 | ^2.2",
-        "dingo/blueprint": "~0.4"
+        "phpunit/phpunit": "^9.0|^10.0",
+        "squizlabs/php_codesniffer": "~2.0"
     },
     "suggest": {
         "php-open-source-saver/jwt-auth": "Protect your API with JSON Web Tokens.",

--- a/src/Transformer/Adapter/Fractal.php
+++ b/src/Transformer/Adapter/Fractal.php
@@ -9,10 +9,12 @@ use Dingo\Api\Contract\Transformer\Adapter;
 use PHPOpenSourceSaver\Fractal\Manager as FractalManager;
 use PHPOpenSourceSaver\Fractal\Resource\Item as FractalItem;
 use PHPOpenSourceSaver\Fractal\Pagination\IlluminatePaginatorAdapter;
+use PHPOpenSourceSaver\Fractal\Pagination\IlluminateSimplePaginatorAdapter;
 use Illuminate\Support\Collection as IlluminateCollection;
 use PHPOpenSourceSaver\Fractal\Resource\Collection as FractalCollection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Contracts\Pagination\Paginator as IlluminatePaginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator as IlluminateLengthAwarePaginator;
 
 class Fractal implements Adapter
 {
@@ -127,11 +129,15 @@ class Fractal implements Adapter
      * Create the Fractal paginator adapter.
      *
      * @param \Illuminate\Contracts\Pagination\Paginator $paginator
-     * @return \PHPOpenSourceSaver\Fractal\Pagination\IlluminatePaginatorAdapter
+     * @return IlluminatePaginatorAdapter|IlluminateSimplePaginatorAdapter
      */
     protected function createPaginatorAdapter(IlluminatePaginator $paginator)
     {
-        return new IlluminatePaginatorAdapter($paginator);
+        if ($paginator instanceof IlluminateLengthAwarePaginator) {
+            return new IlluminatePaginatorAdapter($paginator);
+        } else {
+            return new IlluminateSimplePaginatorAdapter($paginator);
+        }
     }
 
     /**

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -3,6 +3,8 @@
 namespace Dingo\Api\Tests;
 
 use Dingo\Api\Http\Response;
+use Dingo\Api\Tests\Stubs\TranslatorStub;
+use Illuminate\Container\Container;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +23,10 @@ class BaseTestCase extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+    }
+
+    protected function setupTranslator(): void
+    {
+        app()->singleton('translator', TranslatorStub::class);;
     }
 }

--- a/tests/ChecksLaravelVersionTrait.php
+++ b/tests/ChecksLaravelVersionTrait.php
@@ -28,7 +28,7 @@ trait ChecksLaravelVersionTrait
         // Find laravel/framework or lumen package
         $just_laravel = array_filter($parsed_data, function ($composerPackageData) {
             if (is_array($composerPackageData) && array_key_exists('name', $composerPackageData)) {
-                if ('laravel/framework' === $composerPackageData['name'] || 'laravel/lumen-framework' === $composerPackageData['name']) {
+                if ('laravel/framework' === $composerPackageData['name']) {
                     return true;
                 }
             }

--- a/tests/Http/Response/FactoryTest.php
+++ b/tests/Http/Response/FactoryTest.php
@@ -7,6 +7,7 @@ use Dingo\Api\Http\Response\Factory;
 use Dingo\Api\Tests\BaseTestCase;
 use Dingo\Api\Tests\Stubs\UserStub;
 use Dingo\Api\Transformer\Factory as TransformerFactory;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use PHPOpenSourceSaver\Fractal\Manager;
@@ -27,6 +28,7 @@ class FactoryTest extends BaseTestCase
 
     public function setUp(): void
     {
+        parent::setUp();
         $this->transformer = Mockery::mock(TransformerFactory::class);
         $this->factory = new Factory($this->transformer);
     }
@@ -127,6 +129,16 @@ class FactoryTest extends BaseTestCase
     }
 
     public function testMakingPaginatorRegistersUnderlyingClassWithTransformer()
+    {
+        $this->setupTranslator();
+
+        $this->transformer->shouldReceive('register')->twice()->with(UserStub::class, 'test', [], null);
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $this->factory->paginator(new LengthAwarePaginator([new UserStub('Jason')], 1, 1), 'test')->getOriginalContent());
+        $this->assertInstanceOf(LengthAwarePaginator::class, $this->factory->withPaginator(new LengthAwarePaginator([new UserStub('Jason')], 1, 1), 'test')->getOriginalContent());
+    }
+
+    public function testMakingSimplePaginatorRegistersUnderlyingClassWithTransformer()
     {
         $this->transformer->shouldReceive('register')->twice()->with(UserStub::class, 'test', [], null);
 

--- a/tests/Http/Response/Format/JsonTest.php
+++ b/tests/Http/Response/Format/JsonTest.php
@@ -7,6 +7,8 @@ use Dingo\Api\Http\Response\Format\Json;
 use Dingo\Api\Tests\BaseTestCase;
 use Dingo\Api\Tests\Stubs\EloquentModelStub;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\MessageBag;
 
 class JsonTest extends BaseTestCase
@@ -51,6 +53,25 @@ class JsonTest extends BaseTestCase
         $response = (new Response(new Collection([new EloquentModelStub, new EloquentModelStub])))->morph();
 
         $this->assertSame('{"foo_bars":[{"foo":"bar"},{"foo":"bar"}]}', $response->getContent());
+    }
+
+    public function testMorphLengthAwarePaginator()
+    {
+        $response = (new Response(new LengthAwarePaginator([new EloquentModelStub, new EloquentModelStub], 2, 10)))->morph();
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('total', $content);
+        $this->assertSame(2, $content['total']);
+    }
+
+    public function testMorphSimplePaginator()
+    {
+        $response = (new Response(new Paginator([new EloquentModelStub, new EloquentModelStub], 2, 1)))->morph();
+
+        $content = json_decode($response->getContent(), true);
+
+        $this->assertArrayNotHasKey('total', $content);
     }
 
     public function testMorphingEmptyEloquentCollection()

--- a/tests/Stubs/TranslatorStub.php
+++ b/tests/Stubs/TranslatorStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Dingo\Api\Tests\Stubs;
+
+use Illuminate\Contracts\Translation\Translator;
+
+class TranslatorStub implements Translator
+{
+
+    public function get($key, array $replace = [], $locale = null)
+    {
+        return $key;
+    }
+
+    public function choice($key, $number, array $replace = [], $locale = null)
+    {
+        return $key;
+    }
+
+    public function getLocale()
+    {
+        return 'en';
+    }
+
+    public function setLocale($locale)
+    {
+    }
+}


### PR DESCRIPTION
This allows developers to pass simple paginator, and this will now use the new simple paginator adapter in fractal. This is useful if you don't want to use the length aware paginator, to avoid the `count(*)` query.