### PR TITLE
Improve reporting of exceptions (isReportable)

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -91,7 +91,7 @@ class Handler implements ExceptionHandler, IlluminateExceptionHandler
      */
     public function shouldReport(Throwable $e)
     {
-        return true;
+        return $this->parentHandler->shouldReport($e);
     }
 
     /**


### PR DESCRIPTION
Use the parent (illuminate) handler to determine whether we should report the exception.