### PR TITLE
Fixing PHP 8.4 deprecations

### DIFF
--- a/src/Exception/InternalHttpException.php
+++ b/src/Exception/InternalHttpException.php
@@ -20,12 +20,12 @@ class InternalHttpException extends HttpException
      *
      * @param \Symfony\Component\HttpFoundation\Response $response
      * @param string                                     $message
-     * @param \Exception                                 $previous
+     * @param \Exception|null                            $previous
      * @param array                                      $headers
      * @param int                                        $code
      * @return void
      */
-    public function __construct(Response $response, $message = null, Exception $previous = null, array $headers = [], $code = 0)
+    public function __construct(Response $response, $message = null, ?Exception $previous = null, array $headers = [], $code = 0)
     {
         $this->response = $response;
 

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -10,13 +10,13 @@ class RateLimitExceededException extends HttpException
     /**
      * Create a new rate limit exceeded exception instance.
      *
-     * @param string     $message
-     * @param \Exception $previous
-     * @param array      $headers
-     * @param int        $code
+     * @param string          $message
+     * @param \Exception|null $previous
+     * @param array           $headers
+     * @param int             $code
      * @return void
      */
-    public function __construct($message = null, Exception $previous = null, $headers = [], $code = 0)
+    public function __construct($message = null, ?Exception $previous = null, $headers = [], $code = 0)
     {
         if (array_key_exists('X-RateLimit-Reset', $headers)) {
             $headers['Retry-After'] = $headers['X-RateLimit-Reset'] - time();

--- a/src/Exception/ResourceException.php
+++ b/src/Exception/ResourceException.php
@@ -21,12 +21,12 @@ class ResourceException extends HttpException implements MessageBagErrors
      *
      * @param string                               $message
      * @param \Illuminate\Support\MessageBag|array $errors
-     * @param \Exception                           $previous
+     * @param \Exception|null                      $previous
      * @param array                                $headers
      * @param int                                  $code
      * @return void
      */
-    public function __construct($message = null, $errors = null, Exception $previous = null, $headers = [], $code = 0)
+    public function __construct($message = null, $errors = null, ?Exception $previous = null, $headers = [], $code = 0)
     {
         if (is_null($errors)) {
             $this->errors = new MessageBag;

--- a/src/Exception/UnknownVersionException.php
+++ b/src/Exception/UnknownVersionException.php
@@ -10,12 +10,12 @@ class UnknownVersionException extends HttpException
     /**
      * Create a new unknown version exception instance.
      *
-     * @param string     $message
-     * @param \Exception $previous
-     * @param int        $code
+     * @param string          $message
+     * @param \Exception|null $previous
+     * @param int             $code
      * @return void
      */
-    public function __construct($message = null, Exception $previous = null, $code = 0)
+    public function __construct($message = null, ?Exception $previous = null, $code = 0)
     {
         parent::__construct(400, $message ?: 'The version given was unknown or has no registered routes.', $previous, [], $code);
     }

--- a/src/Exception/ValidationHttpException.php
+++ b/src/Exception/ValidationHttpException.php
@@ -10,12 +10,12 @@ class ValidationHttpException extends ResourceException
      * Create a new validation HTTP exception instance.
      *
      * @param \Illuminate\Support\MessageBag|array $errors
-     * @param \Exception                           $previous
+     * @param \Exception|null                      $previous
      * @param array                                $headers
      * @param int                                  $code
      * @return void
      */
-    public function __construct($errors = null, Exception $previous = null, $headers = [], $code = 0)
+    public function __construct($errors = null, ?Exception $previous = null, $headers = [], $code = 0)
     {
         parent::__construct(null, $errors, $previous, $headers, $code);
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -72,13 +72,13 @@ class Response extends IlluminateResponse
     /**
      * Create a new response instance.
      *
-     * @param mixed                          $content
-     * @param int                            $status
-     * @param array                          $headers
-     * @param \Dingo\Api\Transformer\Binding $binding
+     * @param mixed                               $content
+     * @param int                                 $status
+     * @param array                               $headers
+     * @param \Dingo\Api\Transformer\Binding|null $binding
      * @return void
      */
-    public function __construct($content, $status = 200, $headers = [], Binding $binding = null)
+    public function __construct($content, $status = 200, $headers = [], ?Binding $binding = null)
     {
         parent::__construct($content, $status, $headers);
 

--- a/src/Http/Response/Factory.php
+++ b/src/Http/Response/Factory.php
@@ -89,7 +89,7 @@ class Factory
      * @param \Closure|null                  $after
      * @return \Dingo\Api\Http\Response
      */
-    public function collection(Collection $collection, $transformer = null, $parameters = [], Closure $after = null)
+    public function collection(Collection $collection, $transformer = null, $parameters = [], ?Closure $after = null)
     {
         if ($collection->isEmpty()) {
             $class = get_class($collection);
@@ -117,10 +117,10 @@ class Factory
      * @param object                         $item
      * @param null|string|callable|object    $transformer
      * @param array                          $parameters
-     * @param \Closure                       $after
+     * @param \Closure|null                  $after
      * @return \Dingo\Api\Http\Response
      */
-    public function item($item, $transformer = null, $parameters = [], Closure $after = null)
+    public function item($item, $transformer = null, $parameters = [], ?Closure $after = null)
     {
         // Check for $item being null
         if (! is_null($item)) {
@@ -152,7 +152,7 @@ class Factory
      * @param Closure|null $after
      * @return Response
      */
-    public function array(array $array, $transformer = null, $parameters = [], Closure $after = null)
+    public function array(array $array, $transformer = null, $parameters = [], ?Closure $after = null)
     {
         if ($parameters instanceof \Closure) {
             $after = $parameters;
@@ -180,10 +180,10 @@ class Factory
      * @param \Illuminate\Contracts\Pagination\Paginator $paginator
      * @param null|string|callable|object                $transformer
      * @param array                                      $parameters
-     * @param \Closure                                   $after
+     * @param \Closure|null                              $after
      * @return \Dingo\Api\Http\Response
      */
-    public function paginator(Paginator $paginator, $transformer = null, array $parameters = [], Closure $after = null)
+    public function paginator(Paginator $paginator, $transformer = null, array $parameters = [], ?Closure $after = null)
     {
         if ($paginator->isEmpty()) {
             $class = get_class($paginator);

--- a/src/Transformer/Binding.php
+++ b/src/Transformer/Binding.php
@@ -49,10 +49,10 @@ class Binding
      * @param \Illuminate\Container\Container $container
      * @param mixed                           $resolver
      * @param array                           $parameters
-     * @param \Closure                        $callback
+     * @param \Closure|null                        $callback
      * @return void
      */
-    public function __construct(Container $container, $resolver, array $parameters = [], Closure $callback = null)
+    public function __construct(Container $container, $resolver, array $parameters = [], ?Closure $callback = null)
     {
         $this->container = $container;
         $this->resolver = $resolver;

--- a/src/Transformer/Factory.php
+++ b/src/Transformer/Factory.php
@@ -56,7 +56,7 @@ class Factory
      * @param \Closure|null $after
      * @return \Dingo\Api\Transformer\Binding
      */
-    public function register($class, $resolver, array $parameters = [], Closure $after = null)
+    public function register($class, $resolver, array $parameters = [], ?Closure $after = null)
     {
         return $this->bindings[$class] = $this->createBinding($resolver, $parameters, $after);
     }
@@ -124,10 +124,10 @@ class Factory
      *
      * @param string|callable|object $resolver
      * @param array                  $parameters
-     * @param \Closure               $callback
+     * @param \Closure|null               $callback
      * @return \Dingo\Api\Transformer\Binding
      */
-    protected function createBinding($resolver, array $parameters = [], Closure $callback = null)
+    protected function createBinding($resolver, array $parameters = [], ?Closure $callback = null)
     {
         return new Binding($this->container, $resolver, $parameters, $callback);
     }


### PR DESCRIPTION
Addressing issue https://github.com/api-ecosystem-for-laravel/dingo-api/issues/63

Fixing implicitly nullable parameter types deprecations for PHP 8.4 in (https://www.php.net/releases/8.4/en.php#deprecations_and_bc_breaks)

No change in logic. No tests need to be updated.

Phpunit results before and after. 
![Screenshot 2025-07-01 at 3 21 51 pm](https://github.com/user-attachments/assets/1adaee9e-af39-4178-a42b-5d5bf8e62643)
![Screenshot 2025-07-01 at 3 22 15 pm](https://github.com/user-attachments/assets/341a7de3-b2f8-4b01-a118-d637c12b2d99)

The two remaining deprecations are coming from the `php-open-source-saver/fractal` package. I've created a [PR](https://github.com/PHP-Open-Source-Saver/fractal/pull/3) to address these in their repository.
